### PR TITLE
Debug mode: remove warning flag -gnatwe.

### DIFF
--- a/tp_shared.gpr
+++ b/tp_shared.gpr
@@ -50,7 +50,7 @@ abstract project TP_Shared is
    --  Common options used for the Debug and Release modes
 
    Debug_Options :=
-     ("-g", "-gnata", "-gnatVa", "-gnatQ", "-gnato", "-gnatwe", "-Wall");
+     ("-g", "-gnata", "-gnatVa", "-gnatQ", "-gnato", "-Wall");
 
    Release_Options :=
      ("-O2", "-gnatn");


### PR DESCRIPTION
Debug mode: remove warning flag -gnatwe which prevents compilation in debug mode without error as:
templates_parser-xml.adb:33:14: warning: license of withed unit "DOM.Core.Nodes" may be inconsistent
   compilation of templates_parser-xml.adb failed