### PR TITLE
Make sure the Align_On attribute works only in the table content.

### DIFF
--- a/regtests/tests/0134_align_on/alo.tmplt
+++ b/regtests/tests/0134_align_on/alo.tmplt
@@ -1,8 +1,10 @@
 
+Some Text : To Check Aligment
+
 Test 1
 
 @@TABLE'ALIGN_ON(":")@@
-   @_CAPITALIZE:Partition_Names_@ : process @_CAPITALIZE:Partition_Names_@.final;
+   @_CAPITALIZE:Partition_Names_@    :    process @_CAPITALIZE:Partition_Names_@.final;
 @@END_TABLE@@
 
 Test 2

--- a/regtests/tests/0134_align_on/test.out
+++ b/regtests/tests/0134_align_on/test.out
@@ -1,7 +1,9 @@
+Some Text : To Check Aligment
+
 Test 1
 
-   Part1 : process Part1.final;
-   Part2 : process Part2.final;
+   Part1    :    process Part1.final;
+   Part2    :    process Part2.final;
 
 Test 2
 

--- a/src/templates_parser.adb
+++ b/src/templates_parser.adb
@@ -5731,12 +5731,17 @@ package body Templates_Parser is
 
             when Table_Stmt =>
                declare
-                  Start_Pos             : constant Positive :=
+                  Start_Pos             : Positive :=
                                             1 + Length (Results);
                   End_Pos               : Natural := 0;
                   Max_Lines, Max_Expand : Natural;
                begin
                   Get_Max (T, Max_Lines, Max_Expand);
+
+                  if not T.Align_On.Is_Empty then
+                     Flush;
+                     Start_Pos := 1 + Length (Results);
+                  end if;
 
                   Analyze (T.Blocks,
                            Parse_State'(State.F_Params'Length,


### PR DESCRIPTION
Fix the starting point of the content of the table when applying
the alignment.

Add corresponding regression test.

For RC04-043.