### PR TITLE
Add report callbacks when parsing.

### DIFF
--- a/regtests/tests/0135_tag_report/child.tmplt
+++ b/regtests/tests/0135_tag_report/child.tmplt
@@ -1,0 +1,4 @@
+
+@_NAME_@
+--
+@_NOTKNOWN_@

--- a/regtests/tests/0135_tag_report/tag_report.adb
+++ b/regtests/tests/0135_tag_report/tag_report.adb
@@ -1,0 +1,58 @@
+------------------------------------------------------------------------------
+--                             Templates Parser                             --
+--                                                                          --
+--                       Copyright (C) 2019, AdaCore                        --
+--                                                                          --
+--  This is free software;  you can redistribute it  and/or modify it       --
+--  under terms of the  GNU General Public License as published  by the     --
+--  Free Software  Foundation;  either version 3,  or (at your option) any  --
+--  later version.  This software is distributed in the hope  that it will  --
+--  be useful, but WITHOUT ANY WARRANTY;  without even the implied warranty --
+--  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU     --
+--  General Public License for  more details.                               --
+--                                                                          --
+--  You should have  received  a copy of the GNU General  Public  License   --
+--  distributed  with  this  software;   see  file COPYING3.  If not, go    --
+--  to http://www.gnu.org/licenses for a complete copy of the license.      --
+------------------------------------------------------------------------------
+
+with Ada.Strings.Unbounded;
+with Ada.Text_IO;
+
+with Templates_Parser;
+with Templates_Parser.Utils;
+
+procedure Tag_Report is
+
+   use Ada.Strings.Unbounded;
+   use Ada.Text_IO;
+   use Templates_Parser;
+
+   procedure Report
+     (Tag_Name : String;
+      Filename : String := "";
+      Line     : Natural := 0;
+      Reason   : Reason_Kind) is
+   begin
+      Put_Line
+        (Reason_Kind'Image (Reason)
+         & "; T:" & Tag_Name
+         & "; F:" & Filename & ':' & Utils.Image (Line));
+   end Report;
+
+   procedure Call
+     (Template     : String;
+      Translations : Translate_Table)
+   is
+      Result : constant String :=
+                 Parse (Template, Translations, Report => Report'Access);
+   begin
+      null;
+   end Call;
+
+begin
+   Call ("tag_report.tmplt",
+          Translate_Table'
+            (1 => Assoc ("TAG", "tag_value"),
+             2 => Assoc ("NAME", "value")));
+end Tag_Report;

--- a/regtests/tests/0135_tag_report/tag_report.gpr
+++ b/regtests/tests/0135_tag_report/tag_report.gpr
@@ -1,0 +1,26 @@
+------------------------------------------------------------------------------
+--                             Templates Parser                             --
+--                                                                          --
+--                        Copyright (C) 2019, AdaCore                       --
+--                                                                          --
+--  This is free software;  you can redistribute it  and/or modify it       --
+--  under terms of the  GNU General Public License as published  by the     --
+--  Free Software  Foundation;  either version 3,  or (at your option) any  --
+--  later version.  This software is distributed in the hope  that it will  --
+--  be useful, but WITHOUT ANY WARRANTY;  without even the implied warranty --
+--  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU     --
+--  General Public License for  more details.                               --
+--                                                                          --
+--  You should have  received  a copy of the GNU General  Public  License   --
+--  distributed  with  this  software;   see  file COPYING3.  If not, go    --
+--  to http://www.gnu.org/licenses for a complete copy of the license.      --
+------------------------------------------------------------------------------
+
+with "templates_parser";
+
+project Tag_Report is
+
+   for Source_Dirs use (".");
+   for Main use ("tag_report.adb");
+
+end Tag_Report;

--- a/regtests/tests/0135_tag_report/tag_report.tmplt
+++ b/regtests/tests/0135_tag_report/tag_report.tmplt
@@ -1,0 +1,4 @@
+@@INCLUDE@@ child.tmplt
+@_NAME_@
+@_MOI_@
+   --    Just here : @_ICI_@

--- a/regtests/tests/0135_tag_report/test.out
+++ b/regtests/tests/0135_tag_report/test.out
@@ -1,0 +1,4 @@
+UNDEFINED; T:NOTKNOWN; F:child.tmplt:4
+UNDEFINED; T:MOI; F:tag_report.tmplt:3
+UNDEFINED; T:ICI; F:tag_report.tmplt:4
+UNUSED; T:TAG; F::0

--- a/regtests/tests/0135_tag_report/test.py
+++ b/regtests/tests/0135_tag_report/test.py
@@ -1,0 +1,4 @@
+from test_support import *
+
+gprbuild('tag_report')
+run('tag_report')

--- a/src/templates_parser-expr.adb
+++ b/src/templates_parser-expr.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                             Templates Parser                             --
 --                                                                          --
---                     Copyright (C) 1999-2013, AdaCore                     --
+--                     Copyright (C) 1999-2019, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -412,7 +412,7 @@ package body Expr is
    -- Parse --
    -----------
 
-   function Parse (Expression : String) return Tree is
+   function Parse (Expression : String; Line : Natural) return Tree is
 
       Start_Index : Natural := Expression'First;
       Index       : Natural := Expression'First;
@@ -480,7 +480,7 @@ package body Expr is
          loop
             O := Current_Token.Bin_Op;
             Next_Token;
-            N := new Node'(Op, O, N, Relation);
+            N := new Node'(Op, Line, O, N, Relation);
          end loop;
 
          return N;
@@ -669,13 +669,16 @@ package body Expr is
                   Stop  := Current_Token.Stop;
                   N := new Node'
                     (Value,
+                     Line,
                      V => To_Unbounded_String (Expression (Start .. Stop)));
 
                when Var =>
                   Start := Current_Token.Start;
                   Stop  := Current_Token.Stop;
                   N := new Node'
-                    (Var, Var => Data.Build (Expression (Start .. Stop)));
+                    (Var,
+                     Line,
+                     Var => Data.Build (Expression (Start .. Stop)));
 
                when others =>
                   return null;
@@ -687,7 +690,7 @@ package body Expr is
             then
                --  We have a &, let's catenate the result
                Next_Token;
-               return new Node'(Op, O_Cat, N, Var_Val);
+               return new Node'(Op, Line, O_Cat, N, Var_Val);
             else
                return N;
             end if;
@@ -744,7 +747,7 @@ package body Expr is
          loop
             O := Current_Token.Bin_Op;
             Next_Token;
-            N := new Node'(Op, O, N, Term);
+            N := new Node'(Op, Line, O, N, Term);
          end loop;
 
          return N;
@@ -760,7 +763,7 @@ package body Expr is
          if Current_Token.Kind = Unary_Op then
             O := Current_Token.Un_Op;
             Next_Token;
-            return new Node'(U_Op, U_O => O, Next => Primary);
+            return new Node'(U_Op, Line, U_O => O, Next => Primary);
          else
             return Primary;
          end if;

--- a/src/templates_parser-macro.adb
+++ b/src/templates_parser-macro.adb
@@ -251,6 +251,7 @@ package body Macro is
                New_Node : constant Data.Tree :=
                             new Data.Node'
                               (Data.Text,
+                               Line  => C.Line,
                                Col   => Value'First,
                                Next  => C.Next,
                                Value => To_Unbounded_String (Value));
@@ -380,10 +381,11 @@ package body Macro is
                N_Value : constant String :=
                            Data.Translate
                              (T.Var, Value, Ctx'Access);
+               Line    : constant Natural := T.Line;
             begin
                Expr.Release (T, Single => True);
                T := new Expr.Node'
-                 (Expr.Value, V => To_Unbounded_String (N_Value));
+                 (Expr.Value, Line, V => To_Unbounded_String (N_Value));
             end Replace;
 
             procedure Replace (T : in out Expr.Tree; Ref : Positive) is

--- a/src/templates_parser-simplifier.adb
+++ b/src/templates_parser-simplifier.adb
@@ -118,6 +118,7 @@ package body Simplifier is
                               Old := T;
                               T := new Data.Node'
                                 (Kind  => Data.Text,
+                                 Line  => D.Var.Def.Text.Line,
                                  Col   => D.Var.Def.Text.Col,
                                  Next  => D.Var.Def.Text.Next,
                                  Value => To_Unbounded_String

--- a/src/templates_parser.ads
+++ b/src/templates_parser.ads
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                             Templates Parser                             --
 --                                                                          --
---                     Copyright (C) 1999-2018, AdaCore                     --
+--                     Copyright (C) 1999-2019, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -453,13 +453,19 @@ package Templates_Parser is
    -- Parsing and Translating --
    -----------------------------
 
+   type Reason_Kind is (Unused, Undefined);
+
    function Parse
      (Filename          : String;
       Translations      : Translate_Table       := No_Translation;
       Cached            : Boolean               := False;
       Keep_Unknown_Tags : Boolean               := False;
       Lazy_Tag          : Dyn.Lazy_Tag_Access   := Dyn.Null_Lazy_Tag;
-      Cursor_Tag        : Dyn.Cursor_Tag_Access := Dyn.Null_Cursor_Tag)
+      Cursor_Tag        : Dyn.Cursor_Tag_Access := Dyn.Null_Cursor_Tag;
+      Report            : access procedure (Tag_Name : String;
+                                            Filename : String := "";
+                                            Line     : Natural := 0;
+                                            Reason   : Reason_Kind) := null)
       return String
    with Pre => Filename'Length > 0;
    --  Parse the Template_File replacing variables' occurrences by the
@@ -476,7 +482,11 @@ package Templates_Parser is
       Cached            : Boolean               := False;
       Keep_Unknown_Tags : Boolean               := False;
       Lazy_Tag          : Dyn.Lazy_Tag_Access   := Dyn.Null_Lazy_Tag;
-      Cursor_Tag        : Dyn.Cursor_Tag_Access := Dyn.Null_Cursor_Tag)
+      Cursor_Tag        : Dyn.Cursor_Tag_Access := Dyn.Null_Cursor_Tag;
+      Report            : access procedure (Tag_Name : String;
+                                            Filename : String := "";
+                                            Line     : Natural := 0;
+                                            Reason   : Reason_Kind) := null)
       return Unbounded_String
    with Pre => Filename'Length > 0;
    --  Idem but returns an Unbounded_String
@@ -487,7 +497,11 @@ package Templates_Parser is
       Cached            : Boolean               := False;
       Keep_Unknown_Tags : Boolean               := False;
       Lazy_Tag          : Dyn.Lazy_Tag_Access   := Dyn.Null_Lazy_Tag;
-      Cursor_Tag        : Dyn.Cursor_Tag_Access := Dyn.Null_Cursor_Tag)
+      Cursor_Tag        : Dyn.Cursor_Tag_Access := Dyn.Null_Cursor_Tag;
+      Report            : access procedure (Tag_Name : String;
+                                            Filename : String := "";
+                                            Line     : Natural := 0;
+                                            Reason   : Reason_Kind) := null)
       return String
    with Pre => Filename'Length > 0;
    --  Idem with a Translation_Set
@@ -498,7 +512,11 @@ package Templates_Parser is
       Cached            : Boolean               := False;
       Keep_Unknown_Tags : Boolean               := False;
       Lazy_Tag          : Dyn.Lazy_Tag_Access   := Dyn.Null_Lazy_Tag;
-      Cursor_Tag        : Dyn.Cursor_Tag_Access := Dyn.Null_Cursor_Tag)
+      Cursor_Tag        : Dyn.Cursor_Tag_Access := Dyn.Null_Cursor_Tag;
+      Report            : access procedure (Tag_Name : String;
+                                            Filename : String := "";
+                                            Line     : Natural := 0;
+                                            Reason   : Reason_Kind) := null)
       return Unbounded_String
    with Pre => Filename'Length > 0;
    --  Idem with a Translation_Set


### PR DESCRIPTION
The callback is used to report Unused and/or Undefined tags. This make
it possible to implement some safety checks while parsing a template.

Add correspoinding regression test.

For RC04-043.