### PR TITLE
Fix warning message: table_align.adb file name does not match unit name.

### DIFF
--- a/docs/src/table_align.adb
+++ b/docs/src/table_align.adb
@@ -2,7 +2,7 @@
 with Ada.Text_IO;
 with Templates_Parser;
 
-procedure Table_Section is
+procedure Table_Align is
 
    use type Templates_Parser.Vector_Tag;
 
@@ -16,4 +16,4 @@ procedure Table_Section is
 begin
    Ada.Text_IO.Put_Line
      (Templates_Parser.Parse ("table_align.tmplt", Translations));
-end Table_Section;
+end Table_Align;


### PR DESCRIPTION
table_align.adb:5:11: warning: file name does not match unit name, should be "table_section.adb"