### PR TITLE
After a "make", git status reports 3 untracked files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ docs/user.tmplt.texi
 makefile.setup
 regtests/*.pyc
 regtests/out
+config/setup/foo.ads.stderr
+config/setup/foo.ads.stdout
+tp_xmlada.gpr


### PR DESCRIPTION
After a `make`, `git status` reports 3 untracked files - these should be ignored, no?