### PR TITLE
Move LDFLAGS in linker command line before -l library options.

### DIFF
--- a/templates_parser.gpr
+++ b/templates_parser.gpr
@@ -32,7 +32,8 @@ library project Templates_Parser is
 
    case TP_Shared.Library_Type is
       when "relocatable" =>
-         for Library_Options use TP_Shared.Ldflags;
+         --  Put options like --as-needed before options like -l.
+         for Leading_Library_Options use TP_Shared.Ldflags;
       when others =>
          null;
    end case;

--- a/tp_shared.gpr
+++ b/tp_shared.gpr
@@ -89,7 +89,8 @@ abstract project TP_Shared is
    ------------
 
    package Linker is
-      for Default_Switches ("Ada") use Ldflags;
+      --  Put options like --as-needed before options like -l.
+      for Leading_Switches ("Ada") use Ldflags;
    end Linker;
 
    ---------


### PR DESCRIPTION
Options like --as-needed only affect following libraries,
so --as-needed currently has no effect in Library_Options.
Leading_Options exists exactly for this.