### PR TITLE
Do not generate src/templates_parser-version.adb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,20 +142,8 @@ force:
 
 makefile.setup: setup
 
-version_path := src/templates_parser-version.adb
-
-setup: tp_xmlada.gpr $(version_path) force
+setup: tp_xmlada.gpr force
 	printf " $(foreach v,$(ALL_OPTIONS),$(v) = $($(v))\n)" > makefile.setup
-
-build: $(version_path)
-
-$(version_path):
-	echo "--  Generated, by ../Makefile"      > $(version_path)
-	echo "separate (Templates_Parser)"       >> $(version_path)
-	echo "function Version return String is" >> $(version_path)
-	echo "begin"                             >> $(version_path)
-	echo "   return \"$(VERSION)\";"         >> $(version_path)
-	echo "end Version;"                      >> $(version_path)
 
 #######################################################################
 #  install
@@ -194,7 +182,6 @@ endif
 	$(MAKE) -C docs clean
 	$(MAKE) -C regtests clean
 	rm -f auto.cgpr config/setup/auto.cgpr
-	rm -f src/templates_parser-version.adb
 	rm -fr .build makefile.setup
 	rm -f config/setup/foo.ali config/setup/foo.o tp_xmlada.gpr
 	rm -f config/setup/foo.ads.std*

--- a/src/templates_parser-version.adb
+++ b/src/templates_parser-version.adb
@@ -1,0 +1,8 @@
+with GNAT.Bind_Environment;
+
+separate (Templates_Parser)
+function Version return String is
+   use GNAT;
+begin
+   return Bind_Environment.Get ("version");
+end Version;

--- a/tp_shared.gpr
+++ b/tp_shared.gpr
@@ -73,7 +73,7 @@ abstract project TP_Shared is
    ------------
 
    package Binder is
-      for Default_Switches ("Ada") use ("-E");
+      for Default_Switches ("Ada") use ("-E", "-Vversion=" & Version);
    end Binder;
 
    -------------


### PR DESCRIPTION
Pass the version information via the Bind env to the source instead of generating the source file in the Makefile. This makes the source code independent from the Makefile so that one can easily build from the gpr file only. Can be useful for platform independent integration into Alire as well.