### PR TITLE
Fix the wrong version in documentation. U621-025

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 
 .SILENT:
 
-VERSION	= 20.0
+VERSION	= 22.0
 
 DEBUG        = false
 TP_TASKING   = Standard_Tasking


### PR DESCRIPTION
The version in the Makefile is wrong causing documentation having wrong version. This issue was detected by the internal SC. Fix it for the next release.