### PR TITLE
removed GNATcheck warnings

### DIFF
--- a/src/templates_parser-cached_files.adb
+++ b/src/templates_parser-cached_files.adb
@@ -27,6 +27,7 @@
 --  covered by the  GNU Public License.                                     --
 ------------------------------------------------------------------------------
 
+with Ada.Assertions;
 separate (Templates_Parser)
 
 package body Cached_Files is
@@ -339,12 +340,13 @@ package body Cached_Files is
          return;
       end if;
 
-      case Mode is
-         when Used =>
-            T.Info.Next.Used := T.Info.Next.Used + 1;
-         when Released =>
-            T.Info.Next.Used := T.Info.Next.Used - 1;
-      end case;
+      Ada.Assertions.Assert
+        (Check => Mode in Used | Released, Message => "Value outside expected value set");
+      if Mode in Used then
+         T.Info.Next.Used := T.Info.Next.Used + 1;
+      else
+         T.Info.Next.Used := T.Info.Next.Used - 1;
+      end if;
 
       --  And mark all included files
 

--- a/xsrc/templates_parser-xml.adb
+++ b/xsrc/templates_parser-xml.adb
@@ -27,6 +27,7 @@
 --  covered by the  GNU Public License.                                     --
 ------------------------------------------------------------------------------
 
+with Ada.Assertions;
 with Ada.Strings.Fixed;
 with Ada.Text_IO;
 
@@ -347,10 +348,14 @@ package body Templates_Parser.XML is
          --  Do not process labels encoded for another variable
 
          if not Is_Labels and then not Is_Description then
-            case Item.Kind is
-               when Std       => Process_Std;
-               when Composite => Process_Composite;
-            end case;
+            Ada.Assertions.Assert
+              (Check   => Item.Kind in Std | Composite,
+               Message => "Value outside expected value set");
+            if Item.Kind in Std then
+               Process_Std;
+            else
+               Process_Composite;
+            end if;
          end if;
       end Process;
 


### PR DESCRIPTION
related to rule 11.1.5.6. Binary_Case_statements
See https://docs.adacore.com/live/wave/asis/html/gnatcheck_rm/gnatcheck_rm/predefined_rules.html

Note 1. The changed statements have been pretty printed which might have caused a few more changes than strictly necessary.
Note 2. All subrules (like replace `not (x in y)` by `x not in y`) to get maximally readable code are applied on files with changed case statements. These subrules sometime also change other parts of the files not related to the original / changed case statements.

Note 3. I am curious what the build pipeline produces on other platforms than I have available.