### PR TITLE
Replace self.shell with Run from e3 in testsuite

### DIFF
--- a/regtests/testsuite.py
+++ b/regtests/testsuite.py
@@ -30,7 +30,7 @@ class BasicTestDriver(DiffTestDriver):
         """
         cmd = ["python", "test.py"]
         start_time = time.time()
-        run = self.shell(cmd, catch_error=False)
+        run = Run(cmd, catch_error=False)
         self.result.time = time.time() - start_time
 
 


### PR DESCRIPTION
Rlimit would cause crashes in Windows tests. It was used by e3.testsuite
when calling self.shell, and would result into the following error:
"rlimit: cannot spawn process (error 0x2)".

Fix this with a replacement with Run, from e3.os.process, which should
not call any bug.

TN: V223-017