### PR TITLE
Fix tests on Windows

### DIFF
--- a/regtests/test_support.py
+++ b/regtests/test_support.py
@@ -6,12 +6,6 @@ from e3.os.process import Run
 import os
 import sys
 
-#  Change directory
-TEST = sys.modules["__main__"]
-TESTDIR = os.path.dirname(os.path.realpath(TEST.__file__))
-TEST_NAME = os.path.basename(TESTDIR)
-os.chdir(TESTDIR)
-
 
 def gprbuild(prj):
     """Compile a project with gprbuild"""

--- a/regtests/testsuite.py
+++ b/regtests/testsuite.py
@@ -31,7 +31,12 @@ class BasicTestDriver(DiffTestDriver):
         """
         cmd = [interpreter(), "test.py"]
         start_time = time.time()
-        run = self.shell(cmd, catch_error=False, timeout=None)
+        run = self.shell(
+            cmd,
+            cwd=self.test_env["working_dir"],
+            catch_error=False,
+            timeout=None,
+        )
         self.result.time = time.time() - start_time
 
 

--- a/regtests/testsuite.py
+++ b/regtests/testsuite.py
@@ -12,6 +12,7 @@ import time
 from e3.env import Env
 from e3.os.process import Run
 from e3.fs import mkdir, rm
+from e3.sys import interpreter
 
 import e3.testsuite
 from e3.testsuite import Testsuite
@@ -28,9 +29,9 @@ class BasicTestDriver(DiffTestDriver):
 
         Executes the test.py command inside the tests and compares the results.
         """
-        cmd = ["python", "test.py"]
+        cmd = [interpreter(), "test.py"]
         start_time = time.time()
-        run = Run(cmd, catch_error=False)
+        run = self.shell(cmd, catch_error=False, timeout=None)
         self.result.time = time.time() - start_time
 
 
@@ -40,10 +41,7 @@ class TPTestsuite(Testsuite):
     test_driver_map = {"basic": BasicTestDriver}
     default_driver = "basic"
 
-    def test_name(self, test_dir):
-        # Return the last directory name as the test name.
-        test_directory_name = test_dir.split("/")[-1]
-        return test_directory_name
+    tests_subdir = "tests"
 
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
Hello Pascal,

I did some changes as the tests would crash on Windows (and on Linux, really I did mistakes on the previous PR). 
- Using the system python interpreter instead of "python", more flexible
- Using self.shell instead of Run, would not report the tests output, giving all tests blank (only empty test.out would be valid, now fixed)
- Fixed the file name parsing using test_subdir instead of trying to get the names by redefining test_names (this would make windows tests crash)
- Some clean-up on working directories.

Sorry for the many PRs. This should be good, at last.
Will squash when change is accepted.

Victor.

TN : 223-017