### PR TITLE
Optionally let Make display executed commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@
 #  to http://www.gnu.org/licenses for a complete copy of the license.      #
 ############################################################################
 
+ifndef VERBOSE_MAKE
 .SILENT:
+endif
 
 VERSION	= 22.0
 

--- a/regtests/Makefile
+++ b/regtests/Makefile
@@ -16,7 +16,9 @@
 #  to http://www.gnu.org/licenses for a complete copy of the license.      #
 ############################################################################
 
+ifndef VERBOSE_MAKE
 .SILENT:
+endif
 
 -include ../makefile.setup
 


### PR DESCRIPTION
Debian automatically rebuilds packages on hardware the developper does not possess.  When investigating a failure, a verbose log may save a lot of work: distant connexion, cloning a chroot, installing
build dependencies.
First attempt was suggesting a full removal of .SILENT. This suggestion seems compatible with your workflow (silent builds and `make -n` for debugging if I remember well your answer).