### PR TITLE
Recreate docs/RESDIR components after a clean

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -83,7 +83,7 @@ $(RESFILES): $(RESDIR)/%.adb.res: build-sample | $(RESDIR)
 	( cd $(TMPLDIR) > /dev/null && ../$(EXEDIR)/$* ) > $@
 
 $(RESDIR):
-	mkdir $@
+	mkdir -p $@
 
 .PHONY: build-sample
 build-sample:


### PR DESCRIPTION
docs/build/ may not exist yet when docs/Makefile attempts to create
docs/build/samples/.