### PR TITLE
Let makefile.setup override default values for some variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,6 @@ else
   TP_XMLADA := Disabled
 endif
 
--include makefile.setup
-
 ifeq ($(HOST), $(TARGET))
 GPROPTS		=
 TPREFIX=$(DESTDIR)$(prefix)
@@ -109,6 +107,8 @@ endif
 endif
 endif
 endif
+
+-include makefile.setup
 
 ALL_OPTIONS := \
  DEBUG \


### PR DESCRIPTION
Symptom:
```
make setup PRJ_BUILD=Debug
make
```
answers `gprbuild -p "-XPRJ_BUILD=Release" ...`.

After this commit, the setup value is kept, and no time is spent in subshells computing values that are ignored in the end.

Also, the commit assumes that HOST TP_TASKING GPRINSTALL were unwantedly missing in ALL_OPTIONS and adds them.