### PR TITLE
Switch the documentation's style to use the RTD theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ sys.path.insert(0, os.path.abspath('.'))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = []
+extensions = ['sphinx_rtd_theme']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -95,7 +95,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'sphinxdoc'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
This commit adjust the sphinx configuration to use the "Read The Docs" theme, which has the advantage of allowing the navigation bar (containing among other things a search bar, and the TOC) to stay fixed while scrolling the contents of the page being read. This is particularly useful to allow access to those features while reading a long page, for instance.

TN: VB25-022