### PR TITLE
docs/Makefile: Ensure PRJ_TARGET is passed to GPRbuild.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -89,7 +89,7 @@ $(RESDIR):
 build-sample:
 	$(GPRBUILD) -p -m -Pdocs $(EXEFILES) \
 	  --subdirs=$(SDIR)/static \
-	  $(foreach v,PRJ_BUILD TARGET VERSION,"-X$(v)=$($(v))")
+	  $(foreach v,PRJ_TARGET PRJ_BUILD TARGET VERSION,"-X$(v)=$($(v))")
 
 # Executable and result will be removed with BUILDDIR.
 


### PR DESCRIPTION
Fix compilation error while building documentation.